### PR TITLE
Add `@glimmer/component` 

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function updatePackageJSON(root) {
   pkg.devDependencies = pkg.devDependencies || {};
   pkg.devDependencies['@ember/edition-utils'] = '^1.1.1';
   pkg.devDependencies['@ember/optional-features'] = '^1.0.0';
+  pkg.devDependencies['@glimmer/component'] = '^0.14.0-alpha.13';
 
   fs.writeFileSync(packageJSONPath, JSON.stringify(pkg, null, 2), { encoding: 'utf-8' });
 }

--- a/test.js
+++ b/test.js
@@ -83,6 +83,7 @@ module.exports = {
             '@ember/optional-features': '^1.0.0',
             'ember-cli': '*',
             '@ember/edition-utils': '^1.1.1',
+            '@glimmer/component': '^0.14.0-alpha.13',
           },
         },
         null,


### PR DESCRIPTION
It seems that `@glimmer/component` needs to be added to a project's deps for Octane to work; it's not included in a newly-generated Ember 3.13 app.